### PR TITLE
fix: fix deprecated comment for UploadFile and UploadFileContext

### DIFF
--- a/files.go
+++ b/files.go
@@ -355,14 +355,16 @@ func (api *Client) ListFilesContext(ctx context.Context, params ListFilesParamet
 }
 
 // UploadFile uploads a file.
-// DEPRECATED: Use UploadFileV2 instead. This will stop functioning on March 11, 2025.
+//
+// Deprecated: Use [Client.UploadFileV2] instead. This will stop functioning on March 11, 2025.
 // For more details, see: https://api.slack.com/methods/files.upload#markdown
 func (api *Client) UploadFile(params FileUploadParameters) (file *File, err error) {
 	return api.UploadFileContext(context.Background(), params)
 }
 
 // UploadFileContext uploads a file and setting a custom context.
-// DEPRECATED: Use UploadFileV2Context instead. This will stop functioning on March 11, 2025.
+//
+// Deprecated: Use [Client.UploadFileV2Context] instead. This will stop functioning on March 11, 2025.
 // For more details, see: https://api.slack.com/methods/files.upload#markdown
 func (api *Client) UploadFileContext(ctx context.Context, params FileUploadParameters) (file *File, err error) {
 	// Test if user token is valid. This helps because client.Do doesn't like this for some reason. XXX: More


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated deprecation comments for `UploadFile` and `UploadFileContext` methods to specify alternative methods, enhancing clarity for users. 
	- Improved formatting of deprecation notices for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->